### PR TITLE
Fix of alive devices filter

### DIFF
--- a/bin/metrics-battery.js
+++ b/bin/metrics-battery.js
@@ -17,7 +17,8 @@ r.connect({
       provider: {
           name: `${hostname}`
       },
-      status: 3
+      status: 3,
+      present: true
     })
     .withFields('serial', 'battery', 'provider')
     .run(conn, function(err, cursor) {


### PR DESCRIPTION
Disconnected device can leave the field `status` untouched and change the field `present` instead.